### PR TITLE
Bugfix/aspire binds

### DIFF
--- a/project-templates/content/umbraco-headless-bff/.gitignore
+++ b/project-templates/content/umbraco-headless-bff/.gitignore
@@ -485,6 +485,3 @@ $RECYCLE.BIN/
 
 # Docker bind mounts
 local-data/
-
-# Aspire
-.aspire/

--- a/project-templates/content/umbraco-headless-bff/NuGet.config
+++ b/project-templates/content/umbraco-headless-bff/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />

--- a/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/Directory.Packages.props
+++ b/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/Directory.Packages.props
@@ -1,6 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.3.3" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.3" />

--- a/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/AppHost.cs
+++ b/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/AppHost.cs
@@ -17,7 +17,7 @@ var smtpPort = builder.AddParameter("SmtpPort");
 
 var smtpPortString = await smtpPort.Resource.GetValueAsync(CancellationToken.None);
 
-const string baseBindPath = "../../../local-data/v17/";
+const string baseBindPath = "local-data/v17/";
 
 var mailServer = builder
     .AddMailPit(Services.SmtpServer, 35000, int.Parse(smtpPortString!))
@@ -92,8 +92,9 @@ cms.WithReference(umbracoDb, connectionName: "umbracoDbDSN")
     .WithEnvironment("Umbraco__Storage__AzureBlob__Media__ContainerName", cmsUmbracoBlobContainerNameParameter)
     .WithEnvironment("Umbraco__Storage__AzureBlob__TemporaryFile__ConnectionString", azureBlobStorageResource)
     .WithEnvironment("Umbraco__Storage__AzureBlob__TemporaryFile__ContainerName", cmsUmbracoBlobContainerNameParameter)
-    .WithEnvironment("Umbraco__CMS__DeliveryApi__ApiKey", cmsDeliveryApiKey)
     .WithEnvironment("Umbraco__Storage__Cdn__Url", () => cms.Resource.GetEndpoint("https").Url)
+    .WithEnvironment("Umbraco__CMS__DeliveryApi__ApiKey", cmsDeliveryApiKey)
+    .WithEnvironment("Umbraco__CMS__WebRouting__UmbracoApplicationUrl", () => cms.Resource.GetEndpoint("https").Url)
     .WaitFor(mailServer)
     .WaitFor(umbracoDb)
     .WaitFor(cache)

--- a/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/UmbracoHeadlessBFF.Aspire.AppHost.csproj
+++ b/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/UmbracoHeadlessBFF.Aspire.AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.0.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Hosting.Redis" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />

--- a/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/appsettings.json
+++ b/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/appsettings.json
@@ -1,8 +1,8 @@
 {
   "$schema": "appsettings-schema.json",
   "ConnectionStrings": {
-    "Cache": "<from-secrets>",
-    "umbracoDbDSN": "<from-secrets>",
+    "Cache": "FROM_SECRETS",
+    "umbracoDbDSN": "FROM_SECRETS",
     "umbracoDbDSN_ProviderName": "System.Data.SqlClient"
   },
   "Caching": {
@@ -82,7 +82,7 @@
         }
       },
       "DeliveryApi": {
-        "ApiKey": "<from-secrets>",
+        "ApiKey": "FROM_SECRETS",
         "Enabled": true,
         "PublicAccess": false,
         "RichTextOutputAsJson": false,
@@ -100,7 +100,13 @@
         //#if (false)
         "Id": "eb281fdb-b0b5-41ab-a107-dd0a655c514f",
         //#endif
-        "TimeOut": "01:00:00"
+        "TimeOut": "01:00:00",
+        "Smtp": {
+          "Host": "FROM_ENV_CONFIG",
+          "Port": "FROM_ENV_CONFIG",
+          "Username": "FROM_SECRETS",
+          "Password": "FROM_SECRETS"
+        }
       },
       "Runtime": {
         "Mode": "Production"
@@ -118,18 +124,28 @@
         "UpgradeUnattended": true
       },
       "WebRouting": {
-        "DisableRedirectUrlTracking": true
+        "DisableRedirectUrlTracking": true,
+        "UmbracoApplicationUrl": "FROM_ENV_CONFIG"
+      },
+      //#if (false)
+      "Imaging": {
+        "HMACSecretKey": "yGgS0Ox7EiamMhGXdirYPPlbHpfW8G6Iybg8eEZSyGFUEURnkXLrhRQAhAZd1Fqz4oBjDvplcq/x0Id1BZHhyQ=="
       }
+      //#endif
     },
     "Storage": {
       "AzureBlob": {
         "Media": {
-          "ConnectionString": "<from-secrets>",
-          "ContainerName": "<from-env-config>"
+          "ConnectionString": "FROM_SECRETS",
+          "ContainerName": "FROM_ENV_CONFIG"
+        },
+        "TemporaryFile": {
+          "ConnectionString": "FROM_SECRETS",
+          "ContainerName": "FROM_ENV_CONFIG"
         }
       },
       "Cdn": {
-        "Url": "<from-env-config>",
+        "Url": "FROM_ENV_CONFIG",
         "RemoveMediaFromPath": false
       }
     }
@@ -149,7 +165,7 @@
     }
   },
   "PreviewMode": {
-    "SecretKey": "<from-secrets>"
+    "SecretKey": "FROM_SECRETS"
   },
   "DeliveryApiExtensions": {
     "Preview": {

--- a/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.SiteApi/src/UmbracoHeadlessBFF.SiteApi.Web/appsettings.json
+++ b/project-templates/content/umbraco-headless-bff/UmbracoHeadlessBFF.SiteApi/src/UmbracoHeadlessBFF.SiteApi.Web/appsettings.json
@@ -1,11 +1,11 @@
 {
   "ConnectionStrings": {
-    "Cache": "from-secrets"
+    "Cache": "FROM_SECRETS"
   },
   "Services": {
     "Cms": {
       "Parameters": {
-        "DeliveryApiKey": "<from-secrets>"
+        "DeliveryApiKey": "FROM_SECRETS"
       }
     }
   },

--- a/project-templates/content/umbraco-headless-bff/aspire.config.json
+++ b/project-templates/content/umbraco-headless-bff/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/UmbracoHeadlessBFF.Aspire.AppHost.csproj"
+  }
+}

--- a/project-templates/content/umbraco-headless-bff/clean-local-data.ps1
+++ b/project-templates/content/umbraco-headless-bff/clean-local-data.ps1
@@ -1,0 +1,1 @@
+Remove-Item -Recurse -Force ".\UmbracoHeadlessBFF.Aspire\src\UmbracoHeadlessBFF.Aspire.AppHost\local-data"

--- a/project-templates/content/umbraco-headless-bff/clean-local-data.sh
+++ b/project-templates/content/umbraco-headless-bff/clean-local-data.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rm -rf "./UmbracoHeadlessBFF.Aspire/src/UmbracoHeadlessBFF.Aspire.AppHost/local-data"

--- a/project-templates/content/umbraco-headless-bff/dotnet-format-report.ps1
+++ b/project-templates/content/umbraco-headless-bff/dotnet-format-report.ps1
@@ -1,10 +1,10 @@
 # Define excluded paths
 $EXCLUDED_PATHS_ARRAY = @(
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/umbraco/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/Views/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/wwwroot/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/uSync/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Modules.Common/Umbraco/'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\umbraco\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\Views\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\wwwroot\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\uSync\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Modules.Common\Umbraco/'
 )
 
 # Convert to proper arguments

--- a/project-templates/content/umbraco-headless-bff/dotnet-format.ps1
+++ b/project-templates/content/umbraco-headless-bff/dotnet-format.ps1
@@ -1,10 +1,10 @@
 # Define excluded paths
 $EXCLUDED_PATHS_ARRAY = @(
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/umbraco/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/Views/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/wwwroot/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Web/uSync/'
-    './UmbracoHeadlessBFF.Cms/src/UmbracoHeadlessBFF.Cms.Modules.Common/Umbraco/'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\umbraco\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\Views\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\wwwroot\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Web\uSync\'
+    '.\UmbracoHeadlessBFF.Cms\src\UmbracoHeadlessBFF.Cms.Modules.Common\Umbraco\'
 )
 
 # Convert to proper arguments


### PR DESCRIPTION
Move local-data folder. Update aspire to use the Aspire SDK directly. Consolidate some appsettings.

Moved local-data due to weird bug with bind folders that were cleaned-up/deleted on previous runs on a parent directory.